### PR TITLE
Fix: Remove conflicting CNAME file from public directory

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-yourdomain.com 


### PR DESCRIPTION
The file `public/CNAME` contained 'yourdomain.com' and was likely overwriting the root `CNAME` file (lapscher.com) during the Next.js static export process. This could cause issues with GitHub Pages serving your site correctly under the custom domain.

Removing `public/CNAME` should ensure that the correct CNAME record (`lapscher.com` from the root CNAME file) is used for deployment.