### PR TITLE
Homepage GE DTLP link

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -264,7 +264,7 @@ export default function Home() {
         src: "/images/companies/ge.png",
         alt: "GE Logo"
       },
-      link: "https://careers.gevernova.com/global/en/lp-dtlp"
+      link: "https://careers.gevernova.com/digital-technology-development-program"
     },
     {
       role: "Founder",


### PR DESCRIPTION
Fix broken GE DTLP hyperlink on the homepage.

---
<a href="https://cursor.com/background-agent?bcId=bc-253648ba-1448-4726-be6b-63ba3ae8f0b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-253648ba-1448-4726-be6b-63ba3ae8f0b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

