### PR TITLE
Update current role to Associate at Expense Reduction Coaching

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,12 +23,12 @@ const geistMono = localFont({
 
 export const metadata: Metadata = {
   title: "Joe Lapscher | Product Leader",
-  description: "Joe Lapscher is a Chief Product Officer at Tienda Pago with a passion for building products that make a difference. Experienced in fintech, SaaS, and enterprise software with expertise in product strategy, roadmapping, and team leadership.",
-  keywords: "Chief Product Officer, CPO, product leader, fintech, SaaS, product strategy, roadmapping, team leadership, Tienda Pago, Joe Lapscher",
+  description: "Joe Lapscher is an Associate at Expense Reduction Coaching with a passion for building products that make a difference. Experienced in fintech, SaaS, and enterprise software with expertise in product strategy, roadmapping, and team leadership.",
+  keywords: "Associate, Expense Reduction Coaching, product leader, fintech, SaaS, product strategy, roadmapping, team leadership, Joe Lapscher",
   authors: [{ name: "Joe Lapscher" }],
   openGraph: {
     title: "Joe Lapscher | Product Leader",
-    description: "Chief Product Officer at Tienda Pago. Experienced in fintech, SaaS, and enterprise software with expertise in product strategy, roadmapping, and team leadership.",
+    description: "Associate at Expense Reduction Coaching. Experienced in fintech, SaaS, and enterprise software with expertise in product strategy, roadmapping, and team leadership.",
     url: "https://lapscher.com",
     siteName: "Joe Lapscher Portfolio",
     images: [
@@ -45,7 +45,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Joe Lapscher | Product Leader",
-    description: "Chief Product Officer at Tienda Pago. Product leader with expertise in fintech, SaaS, and enterprise software. Passionate about building products that make a difference.",
+    description: "Associate at Expense Reduction Coaching. Product leader with expertise in fintech, SaaS, and enterprise software. Passionate about building products that make a difference.",
     images: ["https://lapscher.com/images/profile.jpg"],
   },
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -167,8 +167,8 @@ const structuredData = {
   "@context": "https://schema.org",
   "@type": "Person",
   "name": "Joe Lapscher",
-  "jobTitle": "Chief Product Officer",
-  "description": "Chief Product Officer at Tienda Pago with expertise in fintech, SaaS, and enterprise software. Experienced in product strategy, roadmapping, and team leadership.",
+  "jobTitle": "Associate",
+  "description": "Associate at Expense Reduction Coaching with expertise in fintech, SaaS, and enterprise software. Experienced in product strategy, roadmapping, and team leadership.",
   "url": "https://lapscher.com",
   "sameAs": [
     "https://www.linkedin.com/in/ylapscher/",
@@ -176,7 +176,7 @@ const structuredData = {
   ],
   "worksFor": {
     "@type": "Organization",
-    "name": "Tienda Pago"
+    "name": "Expense Reduction Coaching"
   },
   "alumniOf": [
     {
@@ -205,9 +205,19 @@ const structuredData = {
 export default function Home() {
   const experiences: Experience[] = [
     {
+      role: "Associate",
+      company: "Expense Reduction Coaching",
+      duration: "2025 - Present",
+      achievements: [],
+      image: {
+        src: "/images/companies/erc.png",
+        alt: "Expense Reduction Coaching"
+      }
+    },
+    {
       role: "Chief Product Officer",
       company: "Tienda Pago",
-      duration: "2025 - Present",
+      duration: "2025",
       achievements: [
         "I've launched my career into Product leadership and currently own Product, Growth, and Marketing at a LATAM Fintech that provides microloans to bodegas"
       ],
@@ -367,11 +377,11 @@ export default function Home() {
           <h1 className={textStyles.h1}>
             <span className="text-gray-900 dark:text-white">Joe Lapscher</span>
             <span className="block text-xl sm:text-2xl text-gray-700 dark:text-gray-400 mt-2 font-geist-sans">
-              Chief Product Officer
+              Associate at Expense Reduction Coaching
             </span>
           </h1>
           <p className="text-lg text-gray-700 dark:text-gray-400 max-w-2xl mx-auto">
-            Hi! My name is Yoel, but I go by Joe. I'm currently the CPO at Tienda Pago, and this is my corner of the web where I showcase my experience, hobbies, and projects 💻
+            Hi! My name is Yoel, but I go by Joe. I'm currently an Associate at Expense Reduction Coaching, and this is my corner of the web where I showcase my experience, hobbies, and projects 💻
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center mt-6">
             <a

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -25,7 +25,7 @@ export default function Services() {
       <div className="text-center mb-12">
         <h1 className="text-4xl font-bold mb-4 text-gray-900 dark:text-white">How can I help?</h1>
         <p className="text-lg text-gray-700 dark:text-gray-400 max-w-2xl mx-auto">
-          As Chief Product Officer at Tienda Pago, I'm focused on three key areas where I can add immediate value:
+          As an Associate at Expense Reduction Coaching, I'm focused on three key areas where I can add immediate value:
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Added new current role "Associate at Expense Reduction Coaching" to the experience timeline
- Moved TiendaPago CPO role to past experience (duration: "2025" instead of "2025 - Present")
- Updated hero section title and bio to reflect the new role
- Updated all SEO metadata (description, keywords, OpenGraph, Twitter cards) in layout.tsx
- Updated JSON-LD structured data (jobTitle, description, worksFor)
- Updated services page intro text

## Testing
- [ ] Verify hero section displays "Associate at Expense Reduction Coaching"
- [ ] Verify experience timeline shows ERC as current role and TiendaPago as past
- [ ] Verify page metadata/SEO tags reflect updated role
- [ ] Add ERC company logo image at `/images/companies/erc.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)